### PR TITLE
fixes for osx and new brew behavior

### DIFF
--- a/tasks/install_MacOSX.yml
+++ b/tasks/install_MacOSX.yml
@@ -1,5 +1,4 @@
 - homebrew_cask: name=eclipse-jee
-- shell: /usr/local/bin/brew cask info eclipse-jee | grep Caskroom | awk '{print $1}'
-  register: eclipse_folder
-- set_fact: eclipse_home="{{ eclipse_folder.stdout }}/Eclipse.app/Contents/Eclipse"
-- set_fact: eclipse="{{ eclipse_folder.stdout }}/Eclipse.app/Contents/MacOS/eclipse"
+- set_fact: eclipse_folder='/Applications/Eclipse.app/'
+- set_fact: eclipse_home="{{ eclipse_folder }}/Contents/Eclipse"
+- set_fact: eclipse="{{ eclipse_folder }}/Contents/MacOS/eclipse"


### PR DESCRIPTION
Now brew copies the eclipse app to /Applications instead of symlink it.
